### PR TITLE
Install Yarn2 in CI workflow

### DIFF
--- a/.github/workflows/js-qa.yml
+++ b/.github/workflows/js-qa.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           cache: 'yarn'
           node-version: '16'


### PR DESCRIPTION
```
/usr/local/bin/yarn --version
1.22.21
```

but the lock file seems to be v2

I do not know what I am doing in this PR!