### PR TITLE
Set content is not completely unique

### DIFF
--- a/sources/client/src/models/set.ts
+++ b/sources/client/src/models/set.ts
@@ -7,7 +7,7 @@ export class Set< T > {
 	readonly #data: ReadonlyArray< T >;
 
 	public constructor( data: ReadonlyArray< T > = [] ) {
-		this.#data = data;
+		this.#data = this.ensureUnique( data );
 	}
 
 	public add( value: T ): Set< T > {
@@ -29,7 +29,7 @@ export class Set< T > {
 	}
 
 	public has( value: T ): boolean {
-		return this.#data.some( ( current ) => this.isEqual( current, value ) );
+		return this._has( value, this.#data );
 	}
 
 	public map< R = T >( fn: ( value: T ) => R ): Set< R > {
@@ -98,5 +98,20 @@ export class Set< T > {
 
 	private isEqual( a: unknown, b: unknown ): boolean {
 		return _isEqual( a, b );
+	}
+
+	private _has( value: T, data: ReadonlyArray< T > ): boolean {
+		return data.some( ( current ) => this.isEqual( current, value ) );
+	}
+
+	private ensureUnique( data: ReadonlyArray< T > ): ReadonlyArray< T > {
+		const accumulator: Array< T > = [];
+		return data.reduce( ( acc, value ) => {
+			if ( ! this._has( value, acc ) ) {
+				acc.push( value );
+			}
+
+			return acc;
+		}, accumulator );
 	}
 }

--- a/sources/client/src/models/set.ts
+++ b/sources/client/src/models/set.ts
@@ -7,7 +7,7 @@ export class Set< T > {
 	readonly #data: ReadonlyArray< T >;
 
 	public constructor( data: ReadonlyArray< T > = [] ) {
-		this.#data = this.ensureUnique( data );
+		this.#data = this.ensureUniqueness( data );
 	}
 
 	public add( value: T ): Set< T > {
@@ -104,7 +104,7 @@ export class Set< T > {
 		return data.some( ( current ) => this.isEqual( current, value ) );
 	}
 
-	private ensureUnique( data: ReadonlyArray< T > ): ReadonlyArray< T > {
+	private ensureUniqueness( data: ReadonlyArray< T > ): ReadonlyArray< T > {
 		const accumulator: Array< T > = [];
 		return data.reduce( ( acc, value ) => {
 			if ( ! this._has( value, acc ) ) {

--- a/tests/client/unit/models/set.test.ts
+++ b/tests/client/unit/models/set.test.ts
@@ -37,7 +37,7 @@ describe( 'Set', () => {
 		const set1 = set.add( 1 ).add( 2 ).add( 3 );
 		const set2 = set.add( 2 ).add( 3 ).add( 4 );
 		const concat = set1.concat( set2 );
-		expect( concat.length() ).toBe( 6 );
+		expect( concat.length() ).toBe( 4 );
 		expect( concat.has( 1 ) ).toBe( true );
 		expect( concat.has( 2 ) ).toBe( true );
 		expect( concat.has( 3 ) ).toBe( true );
@@ -201,5 +201,12 @@ describe( 'Set', () => {
 			.add( 4 )
 			.add( 6 );
 		expect( set.equals( set2 ) ).toBe( false );
+	} );
+
+	it( 'Should ensure concatenating two sets keep uniqueness', () => {
+		const set1 = new Set< any >().add( { a: { a1: 1 } } ).add( { b: 2 } );
+		const set2 = new Set< any >().add( { a: { a1: 1 } } ).add( { b: 2 } );
+		const concat = set1.concat( set2 );
+		expect( concat.length() ).toBe( 2 );
 	} );
 } );

--- a/tests/client/unit/utils/unique-control-options.test.ts
+++ b/tests/client/unit/utils/unique-control-options.test.ts
@@ -20,7 +20,7 @@ describe( 'Unique Control Options', () => {
 			{ label: 'bar', value: 'bar' },
 		] );
 
-		expect( set.length() ).toBe( 4 );
+		expect( set.length() ).toBe( 2 );
 		const uniqueSet = uniqueControlOptions( set );
 		expect( uniqueSet.length() ).toBe( 2 );
 		expect( uniqueSet.first()?.value ).toBe( 'foo' );


### PR DESCRIPTION
We do not want to have duplicate in our Set, therefore whenever we create a new instance of a Set we do not include in the collection existing elements.

Fix #29 