### PR TITLE
Remove `UPDATE_CONTEXTUAL_ENTITIES_OPTIONS` action

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -117,7 +117,6 @@ declare namespace EntitiesSearch {
 	> extends Readonly<{
 			entities: Entities<E>;
 			kind: Kind<K>;
-			contextualEntitiesOptions: OptionSet;
 			currentEntitiesOptions: OptionSet;
 			selectedEntitiesOptions: OptionSet;
 			searchPhrase: string;
@@ -138,13 +137,6 @@ declare namespace EntitiesSearch {
 					E,
 					K
 				>['currentEntitiesOptions'];
-		  }
-		| {
-				type: 'UPDATE_CONTEXTUAL_ENTITIES_OPTIONS';
-				contextualEntitiesOptions: EntitiesState<
-					E,
-					K
-				>['contextualEntitiesOptions'];
 		  }
 		| {
 				type: 'UPDATE_SELECTED_ENTITIES_OPTIONS';

--- a/sources/client/src/hooks/use-entities-options-storage.ts
+++ b/sources/client/src/hooks/use-entities-options-storage.ts
@@ -64,10 +64,6 @@ export function useEntitiesOptionsStorage< E, K >(
 					selectedEntitiesOptions,
 				} );
 				dispatch( {
-					type: 'UPDATE_CONTEXTUAL_ENTITIES_OPTIONS',
-					contextualEntitiesOptions: currentEntitiesOptions,
-				} );
-				dispatch( {
 					type: 'UPDATE_CURRENT_ENTITIES_OPTIONS',
 					currentEntitiesOptions,
 				} );

--- a/sources/client/src/storage/entities/initial-state.ts
+++ b/sources/client/src/storage/entities/initial-state.ts
@@ -20,7 +20,6 @@ export function makeInitialState< E, K >(
 	return {
 		entities: new Set< E >( [] ),
 		kind: new Set< K >( [] ),
-		contextualEntitiesOptions: new Set< Options< E > >(),
 		currentEntitiesOptions: new Set< Options< E > >(),
 		selectedEntitiesOptions: new Set< Options< E > >(),
 		searchPhrase: '',

--- a/sources/client/src/storage/entities/reducer.ts
+++ b/sources/client/src/storage/entities/reducer.ts
@@ -30,12 +30,6 @@ export function reducer< E, K >(
 				kind: action.kind,
 			};
 
-		case 'UPDATE_CONTEXTUAL_ENTITIES_OPTIONS':
-			return {
-				...state,
-				contextualEntitiesOptions: action.contextualEntitiesOptions,
-			};
-
 		case 'UPDATE_CURRENT_ENTITIES_OPTIONS':
 			return {
 				...state,
@@ -56,14 +50,12 @@ export function reducer< E, K >(
 			return {
 				...state,
 				selectedEntitiesOptions: new Set(),
-				contextualEntitiesOptions: new Set(),
 				currentEntitiesOptions: new Set(),
 			};
 
 		case 'UPDATE_ENTITIES_OPTIONS_FOR_NEW_KIND':
 			return {
 				...state,
-				contextualEntitiesOptions: action.entitiesOptions,
 				currentEntitiesOptions: action.entitiesOptions,
 				selectedEntitiesOptions: new Set(),
 				entities: new Set(),

--- a/tests/client/unit/hooks/use-entities-options-storage.test.tsx
+++ b/tests/client/unit/hooks/use-entities-options-storage.test.tsx
@@ -132,10 +132,6 @@ describe( 'Use Posts Options Storage', () => {
 			selectedEntitiesOptions,
 		} );
 		expect( dispatch ).toHaveBeenCalledWith( {
-			type: 'UPDATE_CONTEXTUAL_ENTITIES_OPTIONS',
-			contextualEntitiesOptions: currentEntitiesOptions,
-		} );
-		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'UPDATE_CURRENT_ENTITIES_OPTIONS',
 			currentEntitiesOptions,
 		} );
@@ -174,10 +170,6 @@ describe( 'Use Posts Options Storage', () => {
 		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'UPDATE_SELECTED_ENTITIES_OPTIONS',
 			selectedEntitiesOptions: expectedSet,
-		} );
-		expect( dispatch ).toHaveBeenCalledWith( {
-			type: 'UPDATE_CONTEXTUAL_ENTITIES_OPTIONS',
-			contextualEntitiesOptions: expectedSet,
 		} );
 		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'UPDATE_CURRENT_ENTITIES_OPTIONS',

--- a/tests/client/unit/storage/initial-state.test.ts
+++ b/tests/client/unit/storage/initial-state.test.ts
@@ -11,7 +11,6 @@ import { makeInitialState } from '../../../../sources/client/src/storage/entitie
 describe( 'Initial state', () => {
 	it( 'ensure all options are empty', () => {
 		const initialState = makeInitialState( {} );
-		expect( initialState.contextualEntitiesOptions.length() ).toBe( 0 );
 		expect( initialState.currentEntitiesOptions.length() ).toBe( 0 );
 		expect( initialState.selectedEntitiesOptions.length() ).toBe( 0 );
 	} );

--- a/tests/client/unit/storage/reducer.test.ts
+++ b/tests/client/unit/storage/reducer.test.ts
@@ -36,27 +36,6 @@ describe( 'reducer', () => {
 		expect( newState.kind ).toEqual( kind );
 	} );
 
-	it( 'Update the Contextual Posts Options', () => {
-		const contextualPostsOptions = new Set( [
-			{
-				value: faker.number.int( 10 ),
-				label: 'Post One',
-			},
-			{
-				value: faker.number.int( { min: 11, max: 20 } ),
-				label: 'Post Two',
-			},
-		] );
-		const newState = reducer( state, {
-			type: 'UPDATE_CONTEXTUAL_ENTITIES_OPTIONS',
-			contextualEntitiesOptions: contextualPostsOptions,
-		} );
-
-		expect( newState.contextualEntitiesOptions ).toEqual(
-			contextualPostsOptions
-		);
-	} );
-
 	it( 'Update the Posts Options', () => {
 		const postsOptions = new Set( [
 			{
@@ -120,7 +99,6 @@ describe( 'reducer', () => {
 		} );
 
 		expect( newState.selectedEntitiesOptions ).toEqual( new Set() );
-		expect( newState.contextualEntitiesOptions ).toEqual( new Set() );
 		expect( newState.currentEntitiesOptions ).toEqual( new Set() );
 	} );
 
@@ -142,7 +120,6 @@ describe( 'reducer', () => {
 			entitiesOptions,
 		} );
 
-		expect( newState.contextualEntitiesOptions ).toEqual( entitiesOptions );
 		expect( newState.currentEntitiesOptions ).toEqual( entitiesOptions );
 		expect( newState.selectedEntitiesOptions ).toEqual( new Set() );
 		expect( newState.entities ).toEqual( new Set() );


### PR DESCRIPTION
This action store a value to a variable in the store which is no longer consumed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified entity options handling by removing `contextualEntitiesOptions`.
- **Tests**
	- Updated tests to reflect changes in entity options handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->